### PR TITLE
[ZEN-7728] Update to sdk 3.4.0

### DIFF
--- a/Activation.Console/Activation.Console.csproj
+++ b/Activation.Console/Activation.Console.csproj
@@ -15,7 +15,7 @@
       <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />
       <PackageReference Include="Sharprompt" Version="2.4.5" />
       <PackageReference Include="Spectre.Console.Json" Version="0.49.1" />
-      <PackageReference Include="Zentitle.Licensing.Client" Version="3.0.0" />
+      <PackageReference Include="Zentitle.Licensing.Client" Version="3.4.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Activation.Console/Zentitle2CoreLibPlaceholder/instructions.txt
+++ b/Activation.Console/Zentitle2CoreLibPlaceholder/instructions.txt
@@ -2,11 +2,17 @@
 and unzip the binaries into to this folder keeping the same structure as in the downloaded zip:
 
 - Zentitle2CoreLibPlaceholder
-  - Linux_x86_64
-    - libZentitle2Core.so
   - MacOS_arm64
     - libZentitle2Core.dylib
   - MacOS_x86_64
     - libZentitle2Core.dylib
   - Windows_x86_64
     - Zentitle2Core.dll
+  - Linux_x86_64
+    - libZentitle2Core.so	
+  - Linux_aarch64	
+    - libZentitle2Core.so
+  - Linux_alpine_aarch64
+    - libZentitle2Core.so  
+  - Linux_alpine_x86_64
+    - libZentitle2Core.so  

--- a/Activation.Console/Zentitle2CoreLibResolver.cs
+++ b/Activation.Console/Zentitle2CoreLibResolver.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
+using System.IO;
 
 namespace Activation.Console
 {
@@ -42,11 +43,31 @@ namespace Activation.Console
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
                 RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD))
             {
+                if (IsAlpineLinux())
+                {
+                    if (RuntimeInformation.OSArchitecture == Architecture.Arm64)
+                    {
+                        return NativeLibrary.Load($"{CoreLibPath}/Linux_alpine_aarch64/libZentitle2Core.so");
+                    }
+
+                    return NativeLibrary.Load($"{CoreLibPath}/Linux_alpine_x86_64/libZentitle2Core.so");
+                }
+
+                if (RuntimeInformation.OSArchitecture == Architecture.Arm64)
+                {
+                    return NativeLibrary.Load($"{CoreLibPath}/Linux_aarch64/libZentitle2Core.so");
+                }
+
                 return NativeLibrary.Load($"{CoreLibPath}/Linux_x86_64/libZentitle2Core.so");
             }
 
             // Otherwise, fallback to default import resolver.
             return IntPtr.Zero;
+        }
+
+        private static bool IsAlpineLinux()
+        {
+            return File.Exists("/etc/alpine-release");
         }
     }
 }

--- a/Net48.Sdk.Sample/Net48.Sdk.Sample.csproj
+++ b/Net48.Sdk.Sample/Net48.Sdk.Sample.csproj
@@ -137,8 +137,8 @@
     <Reference Include="System.Xml.ReaderWriter, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Xml.ReaderWriter.4.3.0\lib\net46\System.Xml.ReaderWriter.dll</HintPath>
     </Reference>
-    <Reference Include="Zentitle.Licensing.Client, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Zentitle.Licensing.Client.3.0.0\lib\net45\Zentitle.Licensing.Client.dll</HintPath>
+    <Reference Include="Zentitle.Licensing.Client, Version=3.4.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Zentitle.Licensing.Client.3.4.0\lib\net45\Zentitle.Licensing.Client.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Net48.Sdk.Sample/packages.config
+++ b/Net48.Sdk.Sample/packages.config
@@ -52,5 +52,5 @@
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="net48" />
   <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net48" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net48" />
-  <package id="Zentitle.Licensing.Client" version="3.0.0" targetFramework="net48" />
+  <package id="Zentitle.Licensing.Client" version="3.4.0" targetFramework="net48" />
 </packages>

--- a/SharedActivation.Console/SharedActivation.Console.csproj
+++ b/SharedActivation.Console/SharedActivation.Console.csproj
@@ -13,7 +13,7 @@
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.4" />
         <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.4" />
-        <PackageReference Include="Zentitle.Licensing.Client" Version="3.0.0" />
+        <PackageReference Include="Zentitle.Licensing.Client" Version="3.4.0" />
         <PackageReference Include="Spectre.Console.Json" Version="0.49.1" />
         <PackageReference Include="Sharprompt" Version="2.4.5" />
     </ItemGroup>

--- a/SharedActivation.Console/Zentitle2CoreLibResolver.cs
+++ b/SharedActivation.Console/Zentitle2CoreLibResolver.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
+using System.IO;
 
 namespace SharedActivation.Console
 {
@@ -10,7 +11,7 @@ namespace SharedActivation.Console
         /// <summary>
         /// Default path to the core library
         /// </summary>
-        private const string CoreLibPath = "Zentitle2CoreLibPlaceholder";
+        private const string CoreLibPath = "Zentitle2Core";
 
         /// <summary>
         /// Should be called once to initialize the resolver.
@@ -28,25 +29,50 @@ namespace SharedActivation.Console
                 if (RuntimeInformation.OSArchitecture == Architecture.X64 ||
                     RuntimeInformation.OSArchitecture == Architecture.X86)
                 {
-                    return NativeLibrary.Load($"{CoreLibPath}/MacOS_x86_64/libZentitle2Core.dylib");
+                    return NativeLibrary.Load(GetCoreLibPath("MacOS_x86_64", "libZentitle2Core.dylib"));
                 }
 
-                return NativeLibrary.Load($"{CoreLibPath}/MacOS_arm64/libZentitle2Core.dylib");
+                return NativeLibrary.Load(GetCoreLibPath("MacOS_arm64", "libZentitle2Core.dylib"));
             }
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                return NativeLibrary.Load($"{CoreLibPath}/Windows_x86_64/Zentitle2Core.dll");
+                return NativeLibrary.Load(GetCoreLibPath("Windows_x86_64", "Zentitle2Core.dll"));
             }
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
                 RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD))
             {
-                return NativeLibrary.Load($"{CoreLibPath}/Linux_x86_64/libZentitle2Core.so");
+                if (IsAlpineLinux())
+                {
+                    if (RuntimeInformation.OSArchitecture == Architecture.Arm64)
+                    {
+                        return NativeLibrary.Load(GetCoreLibPath("Linux_alpine_aarch64", "libZentitle2Core.so"));
+                    }
+
+                    return NativeLibrary.Load(GetCoreLibPath("Linux_alpine_x86_64", "libZentitle2Core.so"));
+                }
+
+                if (RuntimeInformation.OSArchitecture == Architecture.Arm64)
+                {
+                    return NativeLibrary.Load(GetCoreLibPath("Linux_aarch64", "libZentitle2Core.so"));
+                }
+
+                return NativeLibrary.Load(GetCoreLibPath("Linux_x86_64", "libZentitle2Core.so"));
             }
 
             // Otherwise, fallback to default import resolver.
             return IntPtr.Zero;
+        }
+
+        private static string GetCoreLibPath(string platformDirectory, string fileName)
+        {
+            return Path.Combine(AppContext.BaseDirectory, CoreLibPath, platformDirectory, fileName);
+        }
+
+        private static bool IsAlpineLinux()
+        {
+            return File.Exists("/etc/alpine-release");
         }
     }
 }


### PR DESCRIPTION
  Update .NET samples 
  - Replace Zentitle.Licensing.Client 3.0.0 package references to Zentitle.Licensing.Client.3.4.0
  - Update Zentitle2Core library resolvers to support Linux x86_64, Linux aarch64, Alpine x86_64, and Alpine aarch64